### PR TITLE
Fixup for iOS mute controls

### DIFF
--- a/example/client/script/main.js
+++ b/example/client/script/main.js
@@ -88,12 +88,14 @@ function OnMuteButtonClick(_ev) {
     OldVolume = Stream.Volume;
     Stream.Volume = 0.0;
     UpdateVolumeBar(0);
+    document.getElementById("audioTag").muted = trye;
 }
 function OnUnmuteButtonClick(_ev) {
     document.getElementById("mutebutton").style.visibility = "visible";
     document.getElementById("unmutebutton").style.visibility = "hidden";
     Stream.Volume = OldVolume;
     UpdateVolumeBar(OldVolume * document.getElementById("volumebar").getBoundingClientRect().width);
+    document.getElementById("audioTag").muted = false;
 }
 function OnPlayButtonClick(_ev) {
     try {

--- a/example/client/script/main.js
+++ b/example/client/script/main.js
@@ -88,7 +88,7 @@ function OnMuteButtonClick(_ev) {
     OldVolume = Stream.Volume;
     Stream.Volume = 0.0;
     UpdateVolumeBar(0);
-    document.getElementById("audioTag").muted = trye;
+    document.getElementById("audioTag").muted = true;
 }
 function OnUnmuteButtonClick(_ev) {
     document.getElementById("mutebutton").style.visibility = "visible";

--- a/example/client/script/main.ts
+++ b/example/client/script/main.ts
@@ -115,6 +115,7 @@ function OnMuteButtonClick(_ev: MouseEvent): void {
     Stream.Volume = 0.0;
 
     UpdateVolumeBar(0);
+    document.getElementById("audioTag").muted = true;
 }
 
 function OnUnmuteButtonClick(_ev: MouseEvent): void {
@@ -124,6 +125,7 @@ function OnUnmuteButtonClick(_ev: MouseEvent): void {
     Stream.Volume = OldVolume;
 
     UpdateVolumeBar(OldVolume * document.getElementById("volumebar").getBoundingClientRect().width);
+    document.getElementById("audioTag").muted = false;
 }
 
 function OnPlayButtonClick(_ev: MouseEvent): void {


### PR DESCRIPTION
'Temporary' fixup for muting/unmuting audio on iOS, seems like that volume control is not under JavaScript control.
https://stackoverflow.com/questions/27296391/is-there-any-possibility-to-control-html5-audio-volume-on-ios

Unless a rewrite is required to add volume control support with a MediaElementSource, etc.
It would be better to detect if the webpage runs on iOS, and then disable the volume-control bar, to avoid confusion (hidden property)